### PR TITLE
fbgemm and libtorch parity and torch module to half

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__
 *.cpython-*.so
 .idea/
 cmake-build-*/
+.vscode/
+

--- a/inference/inference/examples/SimpleStreamingLibTorchASRExample.cpp
+++ b/inference/inference/examples/SimpleStreamingLibTorchASRExample.cpp
@@ -162,9 +162,17 @@ int main(int argc, char* argv[]) {
     json.ParseStream(isw);
     amDefinitionFile.close();
     auto sequential = getTorchModule(json);
-
+    
+    sequential->to(torch::kFloat16); // wrap loading in float16
     torch::load(
         sequential, GetInputFileFullPath(FLAGS_acoustic_module_parameter_file));
+    // std::ofstream torchmodel = std::ofstream("/tmp/torcham.txt");
+    // for (auto& param: sequential->parameters())
+    // {
+    //     torchmodel << param.data();
+    // }
+    sequential->to(torch::kFloat); // wrap laoding in float16
+
     auto holder = std::make_shared<InferenceModuleTorchHolder>(
         "Sequential",
         static_cast<InferenceModuleTorchHolder::shape>(
@@ -176,7 +184,7 @@ int main(int argc, char* argv[]) {
         torch::nn::AnyModule(sequential));
     acousticModule = std::make_shared<TorchModule>(holder);
   }
-
+  
   // String both modeles togthers to a single DNN.
   auto dnnModule = std::make_shared<streaming::Sequential>();
   dnnModule->add(featureModule);

--- a/inference/inference/module/nn/TorchModule.cpp
+++ b/inference/inference/module/nn/TorchModule.cpp
@@ -28,15 +28,17 @@ std::shared_ptr<ModuleProcessingState> TorchModule::run(
   assert(input);
   std::shared_ptr<ModuleProcessingState> output = input->next();
   assert(output);
-//  assert(input->buffers().size() == 1);
+  // assert(input->buffers().size() == 1);
   std::shared_ptr<IOBuffer> inputBuf = input->buffer(0);
   assert(inputBuf);
 
   int nFrames = inputBuf->size<float>() / holder->inChannels;
-  if (nFrames == 0) {
+  if (nFrames < 80)
+  {
     return output;
   }
   assert(output->buffers().size() == 1);
+
   std::shared_ptr<IOBuffer> outputBuf = output->buffer(0);
   assert(outputBuf);
 
@@ -45,6 +47,7 @@ std::shared_ptr<ModuleProcessingState> TorchModule::run(
   x = holder->anyModule.forward(x).contiguous();
 
   auto outSize = x.numel();
+  auto nOutput_ = outSize / nFrames;
   outputBuf->ensure<float>(outSize);
   auto* outPtr = outputBuf->tail<float>();
   std::copy_n(x.data_ptr<float>(), outSize, outPtr);


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.** Changes *must* be discussed.

**Original Issue**: [corresponding issue on Github]

*Note:* You can add `closes #[issue number]` to automatically close the issue that this PR resolves when it is merged.

### Summary
Solves the disparity between fbgemm and libtorch model outputs.

### Test Plan (required)
[steps by which you tested that your fix resolves the issue. These might include specific commands and configurations]
